### PR TITLE
Fix incorrect spelling of `source`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make install
 
 ```
 module(load="mmgrok")
-action(type="mmgrok" patterndir="path/to/yourpatternsDir" match="%{WORD:test}" soure="msg" target="!msg")
+action(type="mmgrok" patterndir="path/to/yourpatternsDir" match="%{WORD:test}" source="msg" target="!msg")
 template(name="tmlp" type="string" string="%$!msg!test%\n")
 action(type="omfile"  file="path/to/file" template="tmlp")
 ```


### PR DESCRIPTION
I found a incorrect word spelling in `README.md` which may causes unexpected experimental result if people copy the demo configuration directly.
